### PR TITLE
 fixed incorrect deploymentConfigName

### DIFF
--- a/json_files/code_deployment_group.json
+++ b/json_files/code_deployment_group.json
@@ -1,7 +1,7 @@
 {
 	"applicationName": "ecs-linear-blog:ApplicationName",
 	"deploymentGroupName": "ecs-linear-blog:DeploymentGroupName",
-	"deploymentConfigName": "CodeDeployDefault.ECSLinear10PercentEvery1Minute",
+	"deploymentConfigName": "CodeDeployDefault.ECSLinear10PercentEvery1Minutes",
 	"serviceRoleArn": "ecs-linear-blog:EcsRoleForCodeDeploy",
 
 	"deploymentStyle": {


### PR DESCRIPTION
deploymentConfigName was missing 's' at the end "CodeDeployDefault.ECSLinear10PercentEvery1Minute"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
